### PR TITLE
Fix instructions that were named commands

### DIFF
--- a/src/storage/buffer_parser.rs
+++ b/src/storage/buffer_parser.rs
@@ -1,24 +1,24 @@
 use crate::storage::instruction::Instruction;
 
-pub struct CommandBufferParser<'a> {
+pub struct InstructionBufferParser<'a> {
     buffer: &'a [u8],
     index: usize,
 }
 
-impl<'a> CommandBufferParser<'a> {
-    pub fn new(buffer: &[u8], index: usize) -> CommandBufferParser {
-        return CommandBufferParser { buffer, index };
+impl<'a> InstructionBufferParser<'a> {
+    pub fn new(buffer: &[u8], index: usize) -> InstructionBufferParser {
+        return InstructionBufferParser { buffer, index };
     }
 }
 
-impl<'a> Iterator for CommandBufferParser<'a> {
+impl<'a> Iterator for InstructionBufferParser<'a> {
     type Item = (Instruction, usize);
 
     fn next(&mut self) -> Option<Self::Item> {
         match Instruction::parse(&self.buffer[self.index..]) {
-            Ok((command, command_length)) => {
-                self.index += command_length;
-                return Some((command, command_length));
+            Ok((instruction, instruction_length)) => {
+                self.index += instruction_length;
+                return Some((instruction, instruction_length));
             }
             Err(_) => return None,
         }
@@ -27,14 +27,14 @@ impl<'a> Iterator for CommandBufferParser<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::storage::buffer_parser::CommandBufferParser;
+    use crate::storage::buffer_parser::InstructionBufferParser;
     use crate::storage::chain_height::ChainHeight;
     use crate::storage::instruction::Instruction;
     use crate::storage::kvkey::KVKey;
     use crate::storage::kvvalue::KVValue;
 
-    fn get_commands() -> Vec<Instruction> {
-        let commands: Vec<Instruction> = vec![
+    fn get_instructions() -> Vec<Instruction> {
+        let instructions: Vec<Instruction> = vec![
             Instruction::Set {
                 key: KVKey::new(&[0x00, 0x01]),
                 value: KVValue::new(&[0xff, 0xf3]),
@@ -52,55 +52,58 @@ mod tests {
             Instruction::RemoveAll,
         ];
 
-        return commands;
+        return instructions;
     }
 
-    fn serialize_commands(commands: &Vec<Instruction>) -> Vec<u8> {
+    fn serialize_instructions(instructions: &[Instruction]) -> Vec<u8> {
         let mut buffer: Vec<u8> = Vec::new();
-        &commands.to_vec().iter().fold(&mut buffer, |acc, command| {
-            let command_bytes: Vec<u8> = command.serialize();
-            acc.extend_from_slice(&command_bytes);
-            return acc;
-        });
+        &instructions
+            .to_vec()
+            .iter()
+            .fold(&mut buffer, |acc, instruction| {
+                let instruction_bytes: Vec<u8> = instruction.serialize();
+                acc.extend_from_slice(&instruction_bytes);
+                return acc;
+            });
 
         return buffer;
     }
 
     #[test]
     fn iterate_buffer_parser() {
-        let commands = get_commands();
-        let buffer = serialize_commands(&commands);
+        let instructions = get_instructions();
+        let buffer = serialize_instructions(&instructions);
 
-        let command_buffer_parser = CommandBufferParser {
+        let instruction_buffer_parser = InstructionBufferParser {
             buffer: &buffer,
             index: 0,
         };
 
-        for (index, (actual_command, _)) in command_buffer_parser.enumerate() {
-            let expected_command = &commands.as_slice()[index];
-            assert_eq!(&actual_command, expected_command);
+        for (index, (actual_instruction, _)) in instruction_buffer_parser.enumerate() {
+            let expected_instruction = &instructions[index];
+            assert_eq!(&actual_instruction, expected_instruction);
         }
     }
 
     #[test]
-    fn iterate_buffer_parser_with_broken_command() {
-        let commands = get_commands();
-        let mut buffer = serialize_commands(&commands);
+    fn iterate_buffer_parser_with_broken_instruction() {
+        let instructions = get_instructions();
+        let mut buffer = serialize_instructions(&instructions);
 
         let some_broken_bytes = [0xff, 0x00, 0xfa];
         buffer.extend_from_slice(&some_broken_bytes);
 
-        let mut command_buffer_parser = CommandBufferParser {
+        let mut instruction_buffer_parser = InstructionBufferParser {
             buffer: &buffer,
             index: 0,
         };
 
-        for expected_command in commands {
-            let (actual_command, _) = &command_buffer_parser.next().unwrap();
-            assert_eq!(actual_command, &expected_command);
+        for expected_instruction in instructions {
+            let (actual_instruction, _) = &instruction_buffer_parser.next().unwrap();
+            assert_eq!(actual_instruction, &expected_instruction);
         }
 
-        let broken_piece = command_buffer_parser.next();
+        let broken_piece = instruction_buffer_parser.next();
         assert_eq!(broken_piece, None);
     }
 }

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -12,7 +12,7 @@ pub enum KVError {
     RevertOutOfRange,
     ParseIntError(ParseIntError),
     ChainHeightError(ChainHeightError),
-    PointToUnexpectedCommand,
+    PointToUnexpectedInstruction,
     TransactionManagerError(TransactionManagerError),
 }
 


### PR DESCRIPTION
KV-level operations were renamed from "Command" to "Instruction", consistent with Immux 1 design.
However, some variables, which are of the type `Instruction`, are still named `command`.
This PR renames these variables.