### PR TITLE
Refactor LogWriter and Extract LogReader

### DIFF
--- a/src/storage/log_reader.rs
+++ b/src/storage/log_reader.rs
@@ -1,0 +1,37 @@
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, Read, Result, Seek, SeekFrom};
+use std::path::PathBuf;
+
+use crate::storage::errors::KVResult;
+use crate::storage::instruction::Instruction;
+use crate::storage::instruction_iterator::InstructionIterator;
+use crate::storage::log_pointer::LogPointer;
+
+pub struct LogReader {
+    buf_reader: BufReader<File>,
+}
+
+impl LogReader {
+    pub fn new(file_path: &PathBuf) -> Result<Self> {
+        let file = OpenOptions::new().read(true).open(file_path)?;
+        let reader = BufReader::new(file);
+
+        Ok(LogReader { buf_reader: reader })
+    }
+
+    pub fn read_pointer(&mut self, log_pointer: &LogPointer) -> KVResult<Instruction> {
+        let mut buffer = vec![0; log_pointer.len];
+        self.buf_reader.seek(SeekFrom::Start(log_pointer.pos))?;
+        self.buf_reader.read_exact(&mut buffer)?;
+        let (instruction, _) = Instruction::parse(buffer.as_slice())?;
+        return Ok(instruction);
+    }
+
+    pub fn read_all(&mut self) -> KVResult<InstructionIterator> {
+        let mut buffer: Vec<u8> = Vec::with_capacity(self.buf_reader.capacity());
+        self.buf_reader.seek(SeekFrom::Start(0))?;
+        self.buf_reader.read_to_end(&mut buffer)?;
+        let iterator = InstructionIterator::from(buffer);
+        return Ok(iterator);
+    }
+}

--- a/src/storage/log_writer.rs
+++ b/src/storage/log_writer.rs
@@ -1,34 +1,49 @@
-use std::fs::File;
-use std::io::Result;
-use std::io::{BufWriter, Seek, SeekFrom, Write};
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Result, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+use crate::storage::instruction::Instruction;
+use crate::storage::log_pointer::LogPointer;
 
 pub struct LogWriter {
-    writer: BufWriter<File>,
+    buf_writer: BufWriter<File>,
     pos: u64,
 }
 
 impl LogWriter {
-    pub fn new(file: File) -> Result<Self> {
+    pub fn new(file_path: &PathBuf) -> Result<Self> {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(file_path)?;
         let mut writer = BufWriter::new(file);
-        let current_pos = writer.seek(SeekFrom::Current(0))?;
+        let initial_pos = writer.seek(SeekFrom::Current(0))?;
 
         Ok(LogWriter {
-            writer,
-            pos: current_pos,
+            buf_writer: writer,
+            pos: initial_pos,
         })
     }
 
-    pub fn get_current_pos(&self) -> u64 {
-        self.pos
+    pub fn append_instruction(&mut self, instruction: &Instruction) -> Result<LogPointer> {
+        let instruction_bytes = instruction.serialize();
+
+        let pos_before_writing = self.pos;
+        self.write_all(instruction_bytes.as_slice())?;
+        self.flush()?;
+
+        let pointer_to_instruction = LogPointer::new(pos_before_writing, instruction_bytes.len());
+
+        return Ok(pointer_to_instruction);
     }
 
-    pub fn write_all(&mut self, data: &[u8]) -> Result<()> {
-        self.writer.write_all(data)?;
+    fn write_all(&mut self, data: &[u8]) -> Result<()> {
+        self.buf_writer.write_all(data)?;
         self.pos += data.len() as u64;
         return Ok(());
     }
 
-    pub fn flush(&mut self) -> Result<()> {
-        self.writer.flush()
+    fn flush(&mut self) -> Result<()> {
+        self.buf_writer.flush()
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,11 +1,12 @@
-pub mod buffer_parser;
 pub mod chain_height;
 pub mod errors;
 pub mod executor;
 pub mod instruction;
+pub mod instruction_iterator;
 pub mod kv;
 pub mod kvkey;
 pub mod kvvalue;
 pub mod log_pointer;
+pub mod log_reader;
 pub mod log_writer;
 pub mod transaction_manager;

--- a/src/storage/tests/test_kv.rs
+++ b/src/storage/tests/test_kv.rs
@@ -15,14 +15,14 @@ mod kv_tests {
     use immuxsys::storage::executor::outcome::Outcome;
     use immuxsys::storage::executor::unit_content::UnitContent;
     use immuxsys::storage::executor::unit_key::UnitKey;
-    use immuxsys::storage::kv::{get_log_file_dir, LogKeyValueStore};
+    use immuxsys::storage::kv::{get_log_file_path, LogKeyValueStore};
     use immuxsys::storage::kvkey::KVKey;
     use immuxsys::storage::kvvalue::KVValue;
     use immuxsys::storage::transaction_manager::TransactionId;
     use immuxsys::utils::ints::{u64_to_u8_array, u8_array_to_u64};
 
     fn get_store_engine(path: &PathBuf) -> LogKeyValueStore {
-        let log_file_path = get_log_file_dir(&path);
+        let log_file_path = get_log_file_path(&path);
 
         if log_file_path.exists() {
             remove_file(log_file_path).unwrap();


### PR DESCRIPTION
In working on ECC, I encouter duplications with LogWriter and Reader logic and worked to refactor it.

The purposes are:
1. Make Log Writer and Reader have clean interfaces: Writer takes `instruction`s and Reader returns `instruction`;
2. Extract similar logic and reduce duplication.

Specific changes are:

1. Create a new type LogReader for KV, similar to LogWriter;
2. Create two API for LogReader: `read_pointer(pointer) -> Instruction` and `read_all() -> InstructionIterator`;
3. Attach `append_instruction(instruction)` to the LogWriter struct;
4. Privatize LogWriter's flush() and write_all() interfaces, because only `append_instruction()` needs them;
5. Remove LogWriter::get_current_pos() method, because only append_instruction() needs it, and that function can directly assess self.pos;
6. Rename `instruction_buffer_parser` to `instruction_iterator`, because its primary usefulness is that it iterates;
7. Make `instruction_iterator` directly take an `Vec<u8>`, rather than `&[u8]`, because it always take a buffer generated by reader anyways – using references involves explicit lifetime parameter and complicates use;

Passes all tests, checks, and formats.