### PR TITLE
Data redundancy for instruction serialization and storage

### DIFF
--- a/benches/anzsic06.rs
+++ b/benches/anzsic06.rs
@@ -7,7 +7,7 @@ use immuxsys::storage::executor::unit_key::UnitKey;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
 use immuxsys_dev_utils::data_models::business::Business;
 use immuxsys_dev_utils::dev_utils::{
-    csv_to_json_table, e2e_verify_correctness, launch_db_server, measure_iteration, notified_sleep,
+    csv_to_json_table, e2e_verify_correctness, launch_test_db_servers, measure_iteration,
     read_usize_from_arguments,
 };
 
@@ -23,8 +23,7 @@ fn main() {
         bench_name, row_limit, report_period
     );
 
-    launch_db_server("bench_anzsic06", Some(port), None).unwrap();
-    notified_sleep(5);
+    launch_test_db_servers("bench_anzsic06", Some(port), None).unwrap();
 
     let paths = vec!["anzsic06"];
     let dataset: Vec<(GroupingLabel, Vec<(UnitKey, UnitContent)>)> = paths

--- a/benches/berka99.rs
+++ b/benches/berka99.rs
@@ -7,7 +7,7 @@ use immuxsys_dev_utils::data_models::berka99::{
     Account, Card, Client, Disp, District, Loan, Order, Trans,
 };
 use immuxsys_dev_utils::dev_utils::{
-    csv_to_json_table, e2e_verify_correctness, launch_db_server, measure_iteration, notified_sleep,
+    csv_to_json_table, e2e_verify_correctness, launch_test_db_servers, measure_iteration,
     read_usize_from_arguments, UnitList,
 };
 
@@ -23,8 +23,7 @@ fn main() {
         bench_name, row_limit, report_period
     );
 
-    launch_db_server("bench_berka99", Some(port), None).unwrap();
-    notified_sleep(5);
+    launch_test_db_servers("bench_berka99", Some(port), None).unwrap();
 
     let paths = vec![
         "account", "card", "client", "disp", "district", "loan", "order", "trans",

--- a/benches/census90.rs
+++ b/benches/census90.rs
@@ -5,7 +5,7 @@ use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
-    csv_to_json_table, e2e_verify_correctness, launch_db_server, measure_iteration, notified_sleep,
+    csv_to_json_table, e2e_verify_correctness, launch_test_db_servers, measure_iteration,
     read_usize_from_arguments,
 };
 use immuxsys_dev_utils::least_squares::solve;
@@ -22,8 +22,7 @@ fn main() {
         bench_name, row_limit, report_period
     );
 
-    launch_db_server("bench_census90", Some(port), None).unwrap();
-    notified_sleep(5);
+    launch_test_db_servers("bench_census90", Some(port), None).unwrap();
 
     let grouping = GroupingLabel::from("census90");
     let table = csv_to_json_table::<CensusEntry>(

--- a/benches/covid.rs
+++ b/benches/covid.rs
@@ -5,7 +5,7 @@ use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
 use immuxsys_dev_utils::data_models::covid::Covid;
 use immuxsys_dev_utils::dev_utils::{
-    csv_to_json_table, e2e_verify_correctness, launch_db_server, measure_iteration, notified_sleep,
+    csv_to_json_table, e2e_verify_correctness, launch_test_db_servers, measure_iteration,
     read_usize_from_arguments, UnitList,
 };
 
@@ -21,8 +21,7 @@ fn main() {
         bench_name, row_limit, report_period
     );
 
-    launch_db_server("bench_covid", Some(port), None).unwrap();
-    notified_sleep(5);
+    launch_test_db_servers("bench_covid", Some(port), None).unwrap();
 
     let paths = vec!["covid"];
 

--- a/benches/inspect_all.rs
+++ b/benches/inspect_all.rs
@@ -5,7 +5,7 @@ use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
-    csv_to_json_table_with_size, launch_db_server, measure_single_operation, notified_sleep,
+    csv_to_json_table_with_size, launch_test_db_servers, measure_single_operation,
 };
 
 #[derive(Clone)]
@@ -36,10 +36,8 @@ fn main() {
     for (index, bench_spec) in bench_specs.iter().enumerate() {
         let project_name = format!("{}_{}", bench_name, index);
         let bench_spec = bench_spec.clone();
-        launch_db_server(&project_name, Some(bench_spec.port), None).unwrap();
+        launch_test_db_servers(&project_name, Some(bench_spec.port), None).unwrap();
     }
-
-    notified_sleep(5);
 
     let mut children_thread = vec![];
 

--- a/benches/inspect_one.rs
+++ b/benches/inspect_one.rs
@@ -3,8 +3,7 @@ use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
-    csv_to_json_table, launch_db_server, measure_iteration, notified_sleep,
-    read_usize_from_arguments,
+    csv_to_json_table, launch_test_db_servers, measure_iteration, read_usize_from_arguments,
 };
 
 fn main() {
@@ -18,8 +17,7 @@ fn main() {
         bench_name, row_limit, report_period
     );
 
-    launch_db_server("bench_inspect_one", Some(port), None).unwrap();
-    notified_sleep(5);
+    launch_test_db_servers("bench_inspect_one", Some(port), None).unwrap();
 
     let grouping = GroupingLabel::from("census90");
     let table = csv_to_json_table::<CensusEntry>(

--- a/benches/remove_all.rs
+++ b/benches/remove_all.rs
@@ -5,7 +5,7 @@ use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
-    csv_to_json_table_with_size, launch_db_server, measure_single_operation, notified_sleep,
+    csv_to_json_table_with_size, launch_test_db_servers, measure_single_operation,
     read_usize_from_arguments,
 };
 
@@ -39,10 +39,8 @@ fn main() {
     for (index, bench_spec) in bench_specs.iter().enumerate() {
         let project_name = format!("{}{}", bench_name, index);
         let bench_spec = bench_spec.clone();
-        launch_db_server(&project_name, Some(bench_spec.port), None).unwrap();
+        launch_test_db_servers(&project_name, Some(bench_spec.port), None).unwrap();
     }
-
-    notified_sleep(5);
 
     let mut children_thread = vec![];
 

--- a/benches/remove_single_unit.rs
+++ b/benches/remove_single_unit.rs
@@ -4,7 +4,7 @@ use immuxsys::storage::executor::unit_content::UnitContent;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
-    csv_to_json_table, e2e_verify_correctness, launch_db_server, measure_iteration, notified_sleep,
+    csv_to_json_table, e2e_verify_correctness, launch_test_db_servers, measure_iteration,
     read_usize_from_arguments, UnitList,
 };
 
@@ -20,8 +20,7 @@ fn main() {
         bench_name, row_limit, report_period
     );
 
-    launch_db_server("bench_remove_single_unit", Some(port), None).unwrap();
-    notified_sleep(5);
+    launch_test_db_servers("bench_remove_single_unit", Some(port), None).unwrap();
 
     let grouping = GroupingLabel::from("census90");
     let table = csv_to_json_table::<CensusEntry>(

--- a/benches/revert_all.rs
+++ b/benches/revert_all.rs
@@ -7,8 +7,7 @@ use immuxsys::storage::executor::unit_content::UnitContent;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
-    csv_to_json_table, launch_db_server, measure_single_operation, notified_sleep,
-    read_usize_from_arguments,
+    csv_to_json_table, launch_test_db_servers, measure_single_operation, read_usize_from_arguments,
 };
 
 fn main() {
@@ -22,8 +21,7 @@ fn main() {
         bench_name, row_limit
     );
 
-    launch_db_server("bench_revert_all", Some(port), None).unwrap();
-    notified_sleep(5);
+    launch_test_db_servers("bench_revert_all", Some(port), None).unwrap();
 
     let grouping = GroupingLabel::from("census90");
     let table = csv_to_json_table::<CensusEntry>(

--- a/benches/revert_single_unit.rs
+++ b/benches/revert_single_unit.rs
@@ -7,8 +7,7 @@ use immuxsys::storage::executor::unit_content::UnitContent;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
-    csv_to_json_table, launch_db_server, measure_iteration, notified_sleep,
-    read_usize_from_arguments,
+    csv_to_json_table, launch_test_db_servers, measure_iteration, read_usize_from_arguments,
 };
 
 fn main() {
@@ -24,8 +23,7 @@ fn main() {
         bench_name, row_limit, report_period
     );
 
-    launch_db_server("bench_revert_single_unit", Some(port), None).unwrap();
-    notified_sleep(5);
+    launch_test_db_servers("bench_revert_single_unit", Some(port), None).unwrap();
 
     let grouping = GroupingLabel::from("census90");
     let table = csv_to_json_table::<CensusEntry>(

--- a/benches/transactional_set.rs
+++ b/benches/transactional_set.rs
@@ -4,7 +4,7 @@ use immuxsys::storage::transaction_manager::TransactionId;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
-    csv_to_json_table, e2e_verify_correctness, launch_db_server, measure_iteration, notified_sleep,
+    csv_to_json_table, e2e_verify_correctness, launch_test_db_servers, measure_iteration,
     read_usize_from_arguments,
 };
 
@@ -20,8 +20,7 @@ fn main() {
         bench_name, row_limit, report_period
     );
 
-    launch_db_server("bench_transactional_set", Some(port), None).unwrap();
-    notified_sleep(5);
+    launch_test_db_servers("bench_transactional_set", Some(port), None).unwrap();
 
     let grouping = GroupingLabel::from("census90");
     let table = csv_to_json_table::<CensusEntry>(

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,13 +1,14 @@
-use std::path::PathBuf;
-
-use immuxsys::constants as Constants;
 use immuxsys::server::errors::ServerResult;
 use immuxsys::server::server::run_db_servers;
+use immuxsys::storage::preferences::DBPreferences;
+
+fn read_args() -> DBPreferences {
+    let args: Vec<String> = std::env::args().collect();
+    return DBPreferences::from_cli_args(&args);
+}
 
 fn main() -> ServerResult<()> {
-    let default_http_port = Constants::HTTP_SERVER_DEFAULT_PORT;
-    let default_tcp_port = Constants::TCP_SERVER_DEFAULT_PORT;
-    let path = PathBuf::from(Constants::TEMP_LOG_FILE_PATH);
-    run_db_servers(&path, Some(default_http_port), Some(default_tcp_port));
+    let prefs = read_args();
+    run_db_servers(&prefs);
     return Ok(());
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -45,8 +45,9 @@ pub const MISSING_FILTER_ARGUMENT_MESSAGE: &str = "FILTER argument missing";
 pub const MISSING_KEY_MESSAGE: &str = "Key not existed";
 pub const MISSING_FILTER_MESSAGE: &str = "FILTER argument missing";
 
-pub const TEMP_LOG_FILE_PATH: &str = "/tmp";
-pub const LOG_FILE_NAME: &str = "command_log";
+pub const TEMP_LOG_FILE_DIR: &str = "/tmp";
+pub const MAIN_LOG_FILENAME: &str = "instruction_log.imm";
+pub const MAIN_LOG_DEFAULT_DIR_UNIX: &str = "/var/immux";
 
 pub const MAX_KEY_LENGTH: usize = 8 * 1024;
 
@@ -70,3 +71,6 @@ pub const FILTER_NOT_EQUAL: &str = "!=";
 pub const FILTER_LESS: &str = "<";
 pub const FILTER_GREATER: &str = ">";
 pub const FILTER_EQUAL: &str = "==";
+
+pub const INSTRUCTION_PACK_MAGIC: [u8; 4] = [0xB1, 0x0C, 0xDA, 0x7A];
+pub const INSTRUCTION_PACK_VERSION: u8 = 0x01;

--- a/src/storage/ecc.rs
+++ b/src/storage/ecc.rs
@@ -1,0 +1,185 @@
+use crate::utils::ints::{get_bit_u8, set_bit_u8};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ECCMode {
+    Identity = 0x00, // No ECC
+    TMR = 0x01,
+}
+
+#[derive(Debug)]
+pub enum ErrorCorrectionError {
+    DataWidthNotDivisibleByModulus(usize),
+}
+
+pub trait ErrorCorrectionCodec {
+    fn encode(&self, data: &[u8]) -> Vec<u8>;
+    fn decode(&self, data: &[u8]) -> Result<Vec<u8>, ErrorCorrectionError>;
+}
+
+// A code that passes data though without any processing
+pub struct IdentityCode {}
+
+impl IdentityCode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ErrorCorrectionCodec for IdentityCode {
+    fn encode(&self, data: &[u8]) -> Vec<u8> {
+        return data.to_vec();
+    }
+    fn decode(&self, data: &[u8]) -> Result<Vec<u8>, ErrorCorrectionError> {
+        return Ok(data.to_vec());
+    }
+}
+
+// Triple modular redundancy, see https://en.wikipedia.org/wiki/Triple_modular_redundancy
+pub struct TripleRedundancyCode {}
+
+impl TripleRedundancyCode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ErrorCorrectionCodec for TripleRedundancyCode {
+    fn encode(&self, data: &[u8]) -> Vec<u8> {
+        let mut result = Vec::with_capacity(data.len() * 3);
+        for _ in 0..3 {
+            result.extend(data);
+        }
+        return result;
+    }
+    fn decode(&self, data: &[u8]) -> Result<Vec<u8>, ErrorCorrectionError> {
+        if data.len() % 3 != 0 {
+            return Err(ErrorCorrectionError::DataWidthNotDivisibleByModulus(
+                data.len(),
+            ));
+        }
+        let mut i = 0;
+        let original_width = data.len() / 3;
+        let mut result = Vec::with_capacity(original_width);
+        while i < original_width {
+            let pos_1 = i;
+            let pos_2 = i + original_width;
+            let pos_3 = i + original_width * 2;
+            let byte: u8 = if data[pos_1] == data[pos_2] && data[pos_2] == data[pos_3] {
+                data[pos_1]
+            } else {
+                let mut output_byte = 0;
+                for digit in 0..8 {
+                    let bit1 = get_bit_u8(data[pos_1], digit);
+                    let bit2 = get_bit_u8(data[pos_2], digit);
+                    let bit3 = get_bit_u8(data[pos_3], digit);
+                    let bit_sum: u8 = bit1 as u8 + bit2 as u8 + bit3 as u8;
+                    let output_bit = if bit_sum >= 2 { true } else { false };
+                    set_bit_u8(&mut output_byte, digit, output_bit);
+                }
+                output_byte
+            };
+            result.push(byte);
+            i += 1;
+        }
+        return Ok(result);
+    }
+}
+
+#[cfg(test)]
+mod ecc_identity_tests {
+    use crate::storage::ecc::{ErrorCorrectionCodec, IdentityCode};
+
+    #[test]
+    fn test_identity_encode() {
+        let input = [1, 20, 200];
+        let codec = IdentityCode::new();
+        let encoded = codec.encode(&input);
+        assert_eq!(encoded, input)
+    }
+
+    #[test]
+    fn test_tmr_decode() {
+        let input = [1, 20, 200];
+        let codec = IdentityCode::new();
+        let decoded = codec.decode(&input).unwrap();
+        assert_eq!(decoded, input)
+    }
+}
+
+#[cfg(test)]
+mod ecc_tmr_tests {
+    use crate::storage::ecc::{ErrorCorrectionCodec, TripleRedundancyCode};
+
+    #[test]
+    fn test_tmr_encode() {
+        let data = [1, 20, 200];
+        let codec = TripleRedundancyCode::new();
+        let encoded = codec.encode(&data);
+        assert_eq!(encoded, [1, 20, 200, 1, 20, 200, 1, 20, 200])
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_tmr_decode() {
+        let table: Vec<(Vec<u8>, Vec<u8>)> = vec![
+            (
+                vec![
+                    0x11, 0x55, 0xff, 0x42,
+                    0x11, 0x55, 0xff, 0x42,
+                    0x11, 0x55, 0xff, 0x42,
+                ],
+                vec![0x11, 0x55, 0xff, 0x42],
+            ),
+            (
+                vec![
+                    0x00, 0x55, 0xff, 0x42,
+                    0x11, 0x55, 0x00, 0x42,
+                    0x11, 0x00, 0xff, 0x42,
+                ],
+                vec![0x11, 0x55, 0xff, 0x42],
+            ),
+        ];
+        let codec = TripleRedundancyCode::new();
+        for row in table {
+            let (input, expected_original) = row;
+            let decoded = codec.decode(&input).unwrap();
+            assert_eq!(decoded, expected_original)
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    // TMR encoded data should has a width divisible by 3
+    fn test_tmr_incorrect_width() {
+        let codec = TripleRedundancyCode::new();
+        codec.decode(&[1, 2, 3, 4]).unwrap();
+    }
+
+    #[test]
+    fn test_tmr_codec_reversibility() {
+        for i in 0..10 {
+            let input: Vec<u8> = [1, 2, 3].repeat(i).iter().map(|n| n * i as u8).collect();
+            let codec = TripleRedundancyCode::new();
+            let output = codec.encode(&input);
+            let input_recovered = codec.decode(&output).unwrap();
+            assert_eq!(input, input_recovered);
+        }
+    }
+
+    #[test]
+    fn test_tar_resistance_to_single_corruption() {
+        let input = vec![0, 1, 2, 3, 255];
+        let codec = TripleRedundancyCode::new();
+        let output = codec.encode(&input);
+
+        // Corrupt every bit one by one and verify correct output
+        for corrupt_position in 0..output.len() {
+            for corrupt_value in 0..255 {
+                let mut corrupted_output = output.clone();
+                corrupted_output[corrupt_position] = corrupt_value; // Corruption
+                let input_recovered = codec.decode(&corrupted_output).unwrap();
+                assert_eq!(input, input_recovered);
+            }
+        }
+    }
+}

--- a/src/storage/executor/executor.rs
+++ b/src/storage/executor/executor.rs
@@ -1,5 +1,4 @@
 use std::convert::TryFrom;
-use std::path::PathBuf;
 
 use crate::storage::chain_height::ChainHeight;
 use crate::storage::executor::command::{Command, CommandError, SelectCondition};
@@ -12,6 +11,7 @@ use crate::storage::executor::unit_key::UnitKey;
 use crate::storage::kv::LogKeyValueStore;
 use crate::storage::kvkey::KVKey;
 use crate::storage::kvvalue::KVValue;
+use crate::storage::preferences::DBPreferences;
 use crate::storage::transaction_manager::TransactionId;
 
 pub struct Executor {
@@ -19,8 +19,8 @@ pub struct Executor {
 }
 
 impl Executor {
-    pub fn open(path: &PathBuf) -> ExecutorResult<Executor> {
-        let store_engine = LogKeyValueStore::open(path)?;
+    pub fn open(preferences: &DBPreferences) -> ExecutorResult<Executor> {
+        let store_engine = LogKeyValueStore::open(preferences)?;
         let executor = Executor { store_engine };
         return Ok(executor);
     }

--- a/src/storage/kv.rs
+++ b/src/storage/kv.rs
@@ -11,6 +11,7 @@ use crate::storage::kvvalue::KVValue;
 use crate::storage::log_pointer::LogPointer;
 use crate::storage::log_reader::LogReader;
 use crate::storage::log_writer::LogWriter;
+use crate::storage::preferences::DBPreferences;
 use crate::storage::transaction_manager::{TransactionId, TransactionManager};
 
 pub struct LogKeyValueStore {
@@ -22,12 +23,12 @@ pub struct LogKeyValueStore {
 }
 
 impl LogKeyValueStore {
-    pub fn open(data_dir: &PathBuf) -> KVResult<LogKeyValueStore> {
-        create_dir_all(&data_dir)?;
+    pub fn open(preferences: &DBPreferences) -> KVResult<LogKeyValueStore> {
+        create_dir_all(&preferences.log_dir)?;
 
-        let log_file_path = get_log_file_path(&data_dir);
+        let log_file_path = get_main_log_full_path(&preferences.log_dir);
 
-        let writer = LogWriter::new(&log_file_path)?;
+        let writer = LogWriter::new(&log_file_path, preferences.ecc_mode)?;
 
         let mut reader = LogReader::new(&log_file_path)?;
         let (key_pointer_map, current_height, transaction_manager) =
@@ -605,8 +606,6 @@ fn update_key_pointer_map(
     }
 }
 
-pub fn get_log_file_path(dir: &PathBuf) -> PathBuf {
-    let log_file_name = format!("{}.log", Constants::LOG_FILE_NAME);
-    let log_path = dir.join(Path::new(&log_file_name));
-    return log_path;
+pub fn get_main_log_full_path(data_dir: &PathBuf) -> PathBuf {
+    return data_dir.join(Path::new(&Constants::MAIN_LOG_FILENAME));
 }

--- a/src/storage/log_reader.rs
+++ b/src/storage/log_reader.rs
@@ -3,8 +3,8 @@ use std::io::{BufReader, Read, Result, Seek, SeekFrom};
 use std::path::PathBuf;
 
 use crate::storage::errors::KVResult;
-use crate::storage::instruction::Instruction;
-use crate::storage::instruction_iterator::InstructionIterator;
+use crate::storage::instruction::{unpack_instruction, Instruction};
+use crate::storage::instruction_iterator::InstructionLogIterator;
 use crate::storage::log_pointer::LogPointer;
 
 pub struct LogReader {
@@ -23,15 +23,16 @@ impl LogReader {
         let mut buffer = vec![0; log_pointer.len];
         self.buf_reader.seek(SeekFrom::Start(log_pointer.pos))?;
         self.buf_reader.read_exact(&mut buffer)?;
-        let (instruction, _) = Instruction::parse(buffer.as_slice())?;
+        let (instruction, _) = unpack_instruction(&buffer)?;
         return Ok(instruction);
     }
 
-    pub fn read_all(&mut self) -> KVResult<InstructionIterator> {
+    pub fn read_all(&mut self) -> KVResult<InstructionLogIterator> {
         let mut buffer: Vec<u8> = Vec::with_capacity(self.buf_reader.capacity());
         self.buf_reader.seek(SeekFrom::Start(0))?;
         self.buf_reader.read_to_end(&mut buffer)?;
-        let iterator = InstructionIterator::from(buffer);
+
+        let iterator = InstructionLogIterator::from(buffer);
         return Ok(iterator);
     }
 }

--- a/src/storage/log_writer.rs
+++ b/src/storage/log_writer.rs
@@ -2,37 +2,39 @@ use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Result, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
-use crate::storage::instruction::Instruction;
+use crate::storage::ecc::ECCMode;
+use crate::storage::instruction::{pack_instruction, Instruction};
 use crate::storage::log_pointer::LogPointer;
 
 pub struct LogWriter {
     buf_writer: BufWriter<File>,
+    ecc_mode: ECCMode,
     pos: u64,
 }
 
 impl LogWriter {
-    pub fn new(file_path: &PathBuf) -> Result<Self> {
+    pub fn new(file_path: &PathBuf, ecc_mode: ECCMode) -> Result<Self> {
         let file = OpenOptions::new()
             .create(true)
             .append(true)
             .open(file_path)?;
-        let mut writer = BufWriter::new(file);
-        let initial_pos = writer.seek(SeekFrom::Current(0))?;
+        let mut buf_writer = BufWriter::new(file);
+        let initial_pos = buf_writer.seek(SeekFrom::Current(0))?;
 
         Ok(LogWriter {
-            buf_writer: writer,
+            buf_writer,
+            ecc_mode,
             pos: initial_pos,
         })
     }
 
     pub fn append_instruction(&mut self, instruction: &Instruction) -> Result<LogPointer> {
-        let instruction_bytes = instruction.serialize();
-
+        let pack_bytes = pack_instruction(instruction, self.ecc_mode);
         let pos_before_writing = self.pos;
-        self.write_all(instruction_bytes.as_slice())?;
+        self.write_all(&pack_bytes)?;
         self.flush()?;
 
-        let pointer_to_instruction = LogPointer::new(pos_before_writing, instruction_bytes.len());
+        let pointer_to_instruction = LogPointer::new(pos_before_writing, pack_bytes.len());
 
         return Ok(pointer_to_instruction);
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,4 +1,5 @@
 pub mod chain_height;
+pub mod ecc;
 pub mod errors;
 pub mod executor;
 pub mod instruction;
@@ -9,4 +10,5 @@ pub mod kvvalue;
 pub mod log_pointer;
 pub mod log_reader;
 pub mod log_writer;
+pub mod preferences;
 pub mod transaction_manager;

--- a/src/storage/preferences.rs
+++ b/src/storage/preferences.rs
@@ -1,0 +1,106 @@
+use std::path::PathBuf;
+
+use crate::constants as Constants;
+use crate::storage::ecc::ECCMode;
+
+const CLI_ARG_DATA_DIR: &str = "--data-dir=";
+const CLI_ARG_ECC_MODE: &str = "--ecc-mode=";
+const CLI_ARG_HTTP_PORT: &str = "--http-port=";
+const CLI_ARG_TCP_PORT: &str = "--tcp-port=";
+
+#[derive(Clone, Debug)]
+pub struct DBPreferences {
+    pub log_dir: PathBuf,
+    pub ecc_mode: ECCMode,
+    pub http_port: Option<u16>,
+    pub tcp_port: Option<u16>,
+}
+
+impl DBPreferences {
+    pub fn new(
+        log_dir: &str,
+        ecc_mode: ECCMode,
+        http_port: Option<u16>,
+        tcp_port: Option<u16>,
+    ) -> Self {
+        Self {
+            log_dir: PathBuf::from(log_dir),
+            ecc_mode,
+            http_port,
+            tcp_port,
+        }
+    }
+
+    // Same as default(), except dir is changed
+    pub fn default_at_dir(log_dir: &str) -> Self {
+        let mut prefs = Self::default();
+        prefs.log_dir = PathBuf::from(log_dir);
+        return prefs;
+    }
+
+    pub fn from_cli_args(cli_args: &[String]) -> Self {
+        let mut prefs = DBPreferences::default();
+        for arg in cli_args {
+            if arg.starts_with(CLI_ARG_DATA_DIR) {
+                prefs.log_dir = PathBuf::from(arg.replace(CLI_ARG_DATA_DIR, ""));
+            } else if arg.starts_with(CLI_ARG_ECC_MODE) {
+                let desired_mode = arg.replace(CLI_ARG_ECC_MODE, "");
+                match desired_mode.as_str() {
+                    "TMR" => prefs.ecc_mode = ECCMode::TMR,
+                    _ => (),
+                }
+            } else if arg.starts_with(CLI_ARG_HTTP_PORT) {
+                match arg.replace(CLI_ARG_HTTP_PORT, "").parse() {
+                    Ok(port) => prefs.http_port = Some(port),
+                    _ => (),
+                }
+            } else if arg.starts_with(CLI_ARG_TCP_PORT) {
+                match arg.replace(CLI_ARG_TCP_PORT, "").parse() {
+                    Ok(port) => prefs.tcp_port = Some(port),
+                    _ => (),
+                }
+            }
+        }
+        return prefs;
+    }
+}
+
+impl Default for DBPreferences {
+    fn default() -> Self {
+        return Self {
+            log_dir: PathBuf::from(Constants::MAIN_LOG_DEFAULT_DIR_UNIX),
+            ecc_mode: ECCMode::Identity,
+            http_port: Some(Constants::HTTP_SERVER_DEFAULT_PORT),
+            tcp_port: Some(Constants::TCP_SERVER_DEFAULT_PORT),
+        };
+    }
+}
+
+#[cfg(test)]
+mod preference_parsing_tests {
+    use std::path::PathBuf;
+
+    use crate::storage::ecc::ECCMode;
+    use crate::storage::preferences::DBPreferences;
+
+    #[test]
+    fn parse_empty_arg() {
+        let parsed_preference = DBPreferences::from_cli_args(&[]);
+        let default_preference = DBPreferences::default();
+        assert_eq!(parsed_preference.log_dir, default_preference.log_dir);
+        assert_eq!(parsed_preference.tcp_port, default_preference.tcp_port);
+        assert_eq!(parsed_preference.http_port, default_preference.http_port);
+        assert_eq!(parsed_preference.ecc_mode, default_preference.ecc_mode);
+    }
+
+    #[test]
+    fn parse_full_specification() {
+        let args_raw = "--data-dir=/tmp/immux --tcp-port=8888 --http-port=2939 --ecc-mode=TMR";
+        let args: Vec<String> = args_raw.split(" ").map(|s| s.into()).collect();
+        let parsed_preference = DBPreferences::from_cli_args(&args);
+        assert_eq!(parsed_preference.log_dir, PathBuf::from("/tmp/immux"));
+        assert_eq!(parsed_preference.tcp_port, Some(8888));
+        assert_eq!(parsed_preference.http_port, Some(2939));
+        assert_eq!(parsed_preference.ecc_mode, ECCMode::TMR);
+    }
+}

--- a/tests/http_e2e_tests.rs
+++ b/tests/http_e2e_tests.rs
@@ -2,7 +2,6 @@
 mod http_e2e_tests {
     use std::collections::HashMap;
     use std::error::Error;
-    use std::thread;
 
     use immuxsys::constants as Constants;
     use immuxsys::storage::chain_height::ChainHeight;
@@ -19,16 +18,13 @@ mod http_e2e_tests {
     };
     use immuxsys_dev_utils::dev_utils::{
         csv_to_json_table, e2e_verify_correctness, get_filter, get_key_content_pairs,
-        launch_db_server, notified_sleep, UnitList,
+        launch_test_db_servers, UnitList,
     };
 
     #[test]
     fn http_e2e_grouping_get_set() {
         let port = 20030;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_grouping_get_set", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_grouping_get_set", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -105,10 +101,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_wrong_grouping() {
         let port = 20031;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_wrong_grouping", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_wrong_grouping", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -136,10 +129,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_real_data_get_set() {
         let port = 20022;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_real_data_get_set", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_real_data_get_set", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -215,10 +205,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_single_unit_get_set() {
         let port = 10083;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_single_unit_get_set", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_single_unit_get_set", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -246,8 +233,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_revert_one() {
         let port = 10084;
-        thread::spawn(move || launch_db_server("http_e2e_revert_one", Some(port), None).unwrap());
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_revert_one", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -294,8 +280,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_remove_one() {
         let port = 10085;
-        thread::spawn(move || launch_db_server("http_e2e_remove_one", Some(port), None).unwrap());
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_remove_one", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -337,8 +322,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_revert_all() {
         let port = 10086;
-        thread::spawn(move || launch_db_server("http_e2e_revert_all", Some(port), None).unwrap());
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_revert_all", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -377,8 +361,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_remove_all() {
         let port = 10087;
-        thread::spawn(move || launch_db_server("http_e2e_remove_all", Some(port), None).unwrap());
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_remove_all", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -406,10 +389,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_atomicity_commit() {
         let port = 10088;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_atomicity_commit", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_atomicity_commit", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -447,10 +427,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_atomicity_abort() {
         let port = 10089;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_atomicity_abort", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_atomicity_abort", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -487,10 +464,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_set_isolation() {
         let port = 10090;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_set_isolation", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_set_isolation", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -549,10 +523,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_remove_one_isolation() {
         let port = 10091;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_remove_one_isolation", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_remove_one_isolation", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -615,10 +586,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_revert_one_isolation() {
         let port = 10092;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_revert_one_isolation", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_revert_one_isolation", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -677,10 +645,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_remove_all_isolation() {
         let port = 10093;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_remove_all_isolation", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_remove_all_isolation", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -717,10 +682,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_revert_all_isolation() {
         let port = 10094;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_revert_all_isolation", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_revert_all_isolation", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -772,15 +734,12 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_transaction_not_alive_after_revert_all() {
         let port = 10095;
-        thread::spawn(move || {
-            launch_db_server(
-                "http_e2e_transaction_not_alive_after_revert_all",
-                Some(port),
-                None,
-            )
-            .unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers(
+            "http_e2e_transaction_not_alive_after_revert_all",
+            Some(port),
+            None,
+        )
+        .unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -810,15 +769,12 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_unexpected_commit_transaction_id() {
         let port = 10096;
-        thread::spawn(move || {
-            launch_db_server(
-                "http_e2e_unexpected_commit_transaction_id",
-                Some(port),
-                None,
-            )
-            .unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers(
+            "http_e2e_unexpected_commit_transaction_id",
+            Some(port),
+            None,
+        )
+        .unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -832,10 +788,8 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_unexpected_abort_transaction_id() {
         let port = 10097;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_unexpected_abort_transaction_id", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_unexpected_abort_transaction_id", Some(port), None)
+            .unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -849,10 +803,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_last_one_commit_wins() {
         let port = 10098;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_last_one_commit_wins", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_last_one_commit_wins", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -925,10 +876,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_read_inside_transaction() {
         let port = 10099;
-        thread::spawn(move || {
-            launch_db_server("http_e2e_read_inside_transaction", Some(port), None).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_read_inside_transaction", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -962,8 +910,7 @@ mod http_e2e_tests {
     #[test]
     fn http_e2e_dirty_read() {
         let port = 10100;
-        thread::spawn(move || launch_db_server("http_e2e_dirty_read", Some(port), None).unwrap());
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_dirty_read", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();
@@ -1114,8 +1061,7 @@ mod http_e2e_tests {
         contents.extend_from_slice(&unsatisfied_content);
 
         let port = 10011;
-        thread::spawn(move || launch_db_server("http_e2e_filter_read", Some(port), None));
-        notified_sleep(5);
+        launch_test_db_servers("http_e2e_filter_read", Some(port), None).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBHttpClient::new(host).unwrap();

--- a/tests/tcp_e2e_tests.rs
+++ b/tests/tcp_e2e_tests.rs
@@ -2,7 +2,6 @@
 mod tcp_e2e_tests {
     use std::collections::HashMap;
     use std::error::Error;
-    use std::thread;
 
     use immuxsys::constants as Constants;
     use immuxsys::storage::chain_height::ChainHeight;
@@ -20,17 +19,13 @@ mod tcp_e2e_tests {
     use immuxsys_dev_utils::data_models::census90::CensusEntry;
     use immuxsys_dev_utils::data_models::covid::Covid;
     use immuxsys_dev_utils::dev_utils::{
-        csv_to_json_table, get_filter, get_key_content_pairs, launch_db_server, notified_sleep,
-        UnitList,
+        csv_to_json_table, get_filter, get_key_content_pairs, launch_test_db_servers, UnitList,
     };
 
     #[test]
     fn tcp_e2e_grouping_get_set() {
         let port = 8000;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_grouping_get_set", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_grouping_get_set", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -52,10 +47,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_single_unit_get_set() {
         let port = 8001;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_single_unit_get_set", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_single_unit_get_set", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -79,8 +71,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_revert_one() {
         let port = 8002;
-        thread::spawn(move || launch_db_server("tcp_e2e_revert_one", None, Some(port)).unwrap());
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_revert_one", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -121,10 +112,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_real_data_get_set() {
         let port = 8003;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_real_data_get_set", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_real_data_get_set", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -202,8 +190,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_remove_one() {
         let port = 8004;
-        thread::spawn(move || launch_db_server("tcp_e2e_remove_one", None, Some(port)).unwrap());
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_remove_one", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -236,8 +223,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_revert_all() {
         let port = 8005;
-        thread::spawn(move || launch_db_server("tcp_e2e_revert_all", None, Some(port)).unwrap());
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_revert_all", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -271,8 +257,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_remove_all() {
         let port = 8006;
-        thread::spawn(move || launch_db_server("tcp_e2e_remove_all", None, Some(port)).unwrap());
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_remove_all", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -300,10 +285,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_atomicity_commit() {
         let port = 8007;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_atomicity_commit", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_atomicity_commit", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -340,10 +322,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_atomicity_abort() {
         let port = 8008;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_atomicity_abort", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_atomicity_abort", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -381,8 +360,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_set_isolation() {
         let port = 8009;
-        thread::spawn(move || launch_db_server("tcp_e2e_set_isolation", None, Some(port)).unwrap());
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_set_isolation", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -430,10 +408,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_remove_one_isolation() {
         let port = 8010;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_remove_one_isolation", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_remove_one_isolation", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -481,10 +456,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_revert_one_isolation() {
         let port = 8011;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_revert_one_isolation", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_revert_one_isolation", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -538,10 +510,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_remove_all_isolation() {
         let port = 8012;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_remove_all_isolation", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_remove_all_isolation", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -579,10 +548,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_revert_all_isolation() {
         let port = 8013;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_revert_all_isolation", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_revert_all_isolation", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -624,15 +590,12 @@ mod tcp_e2e_tests {
     #[should_panic]
     fn tcp_e2e_transaction_not_alive_after_revert_all() {
         let port = 8014;
-        thread::spawn(move || {
-            launch_db_server(
-                "tcp_e2e_transaction_not_alive_after_revert_all",
-                None,
-                Some(port),
-            )
-            .unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers(
+            "tcp_e2e_transaction_not_alive_after_revert_all",
+            None,
+            Some(port),
+        )
+        .unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -664,10 +627,8 @@ mod tcp_e2e_tests {
     #[should_panic]
     fn tcp_e2e_unexpected_commit_transaction_id() {
         let port = 8016;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_unexpected_commit_transaction_id", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_unexpected_commit_transaction_id", None, Some(port))
+            .unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -681,10 +642,8 @@ mod tcp_e2e_tests {
     #[should_panic]
     fn tcp_e2e_unexpected_abort_transaction_id() {
         let port = 8015;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_unexpected_abort_transaction_id", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_unexpected_abort_transaction_id", None, Some(port))
+            .unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -697,10 +656,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_last_one_commit_wins() {
         let port = 8017;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_last_one_commit_wins", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_last_one_commit_wins", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -767,10 +723,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_read_inside_transaction() {
         let port = 8018;
-        thread::spawn(move || {
-            launch_db_server("tcp_e2e_read_inside_transaction", None, Some(port)).unwrap()
-        });
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_read_inside_transaction", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -798,8 +751,7 @@ mod tcp_e2e_tests {
     #[test]
     fn tcp_e2e_dirty_read() {
         let port = 8019;
-        thread::spawn(move || launch_db_server("tcp_e2e_dirty_read", None, Some(port)).unwrap());
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_dirty_read", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();
@@ -927,8 +879,7 @@ mod tcp_e2e_tests {
         contents.extend_from_slice(&unsatisfied_content);
 
         let port = 8020;
-        thread::spawn(move || launch_db_server("tcp_e2e_filter_read", None, Some(port)).unwrap());
-        notified_sleep(5);
+        launch_test_db_servers("tcp_e2e_filter_read", None, Some(port)).unwrap();
 
         let host = &format!("{}:{}", Constants::SERVER_END_POINT, port);
         let client = ImmuxDBTcpClient::new(host).unwrap();


### PR DESCRIPTION
## A. Summary

This patch adds redundancy in data storage for better data security, by adding meta data for instructions, with optional basic error correction code (**"ECC"** henceforward). It also contains necessary refactoring and bugfixes to implement the features.

## B. Current status

Before this patch, instructions are stored by concatenating their serializations.

This approach allows zero redundancy and has the two issues:–
1. If any byte is corrupt, the whole file could corrupt;
2. The log contains no meta data for the instruction bytes.

## C. Proposed improvement

We use a new concept called "instruction pack", which is the serialization form of an `instruction`.

Before this patch, 
```
instruction_pack = instruction.serialize()
```

Now, we introduce redundancies for more robust data storage and recovery.

```
Item       | bytes | Description
-----------|-------|-------------------------------------------------------------------------------
MAGIC      |   4   | Always B10CDA7A (block data), marking the beginning of an instruction pack
VER        |   1   | Version of serialization format of the pack
ECC width  |   4   | Width the the ECC section, including ECC mode byte
ECC mode   |   1   | ECC mode was used to protect data, 1 for TMR, for example
ECC main   |  vary | Main data of instruction, protected by ECC
```

![Immux-Instruction-Log](https://user-images.githubusercontent.com/233354/94641102-d9c53d00-02cf-11eb-99c1-ff971b00c4da.png)

### 1. Magic number

Instructions are prefixed with 4 constant bytes: `B1 0C DA 7A` (BLOCK DATA).

These bytes are chosen to be unlikely to appear in payload data, so that if a log is partially corrupt, we can use these magic numbers as separators to recover instructions, also if an instruction is transmitted over the networks, the receiver can more easily spot the beginning of an instruction pack.

### 2. Version

The version is an one-byte marker of the version of the serialization format, which allows software upgrade later on. Our log is append-only, and if we upgrade the software, it might have to write new instructions in new format, while keeping the old instruction in old format.

### 3. ECC width

This is a 4-byte section that records the width of the main ECC data section. This create some redundancy in parsing, so that the parser doesn't have to figure out the end by parsing. If we want to skip some instruction later on, the width information will be useful.

This create an implicit size limit for the main data, which tops at about 4GB. With TMR, this means an instruction can at most be about 1.3GB. This is deemed acceptable, because we do not expect people to store that much data in one instruction. For reference, MongoDB allows for 16MB per document and MySQL allows only about 65KB per row.

If in the future, this became an issue, we could still upgrade version for new instruction packs.

### 4. ECC Mode

Currently we have two modes: 
0x00: **Identity**, which means no transformation is used, and the data is written as is, with no error-correction potentials;
0x01: **TMR**, or triple modular redundancy, a fancy name of writing the data three times, and for each bit, we compare the three bits written and choose the majority. Naturally, it will cost 3 times the storage size, and can recover from at most 33% of bit flips.

### 5. ECC data

The instruction data encoded in the chosen error-correction mode. If identity mode is chosen, it is the data itself with no changed. This data, after decoding, is the output of `Instruction::serialize()`.

## D. DB Preferences

To facilitate use, we extracts the handling DB preferences (to `src/storage/preferences.rs`), such as the desired ECC mode. Existing preferences are also handled, for example, location of data storage, and HTTP and TCP ports.

They can be assessed with command line arguments like this, which should be self-explanatory enough.

```
cargo run --bin server --data-dir=/tmp/immux --tcp-port=8888 --http-port=2939 --ecc-mode=TMR
cargo bench --bench census90 -- 100000 20000 --ecc-mode=None
```

## E. Benchmark fix

When I benchmark this PR, I realized that it has been broken: the execution get stuck.

The cause is at commit `0fe4392c5` where we made `dev_utils.rs/launch_db_server` await HTTP and TCP threads, but not all callers of it spawn it in another thread. The benches mostly didn't.

This patch fixes this by making `launch_db_server` always spawn the server itself, so that the callers never have to.

Also, as `notified_sleep` always follows `launch_db_server`, I make `launch_db_server` to call `notified_sleep` so that the callers don't have to

## F. Byte parsing utils

Previously, our `u8_array_to_u64` and friends take fixed width bytes (for type security and performance) and it ends up with rather cumbersome callings:
```
u8_array_to_u64(&[data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]])
```

I created a new set of functions `byte_slice_to_u64` and friends to automatically handle input width. If input is too short, it fills zero. The new calling site would just be:

```
byte_slice_to_u64(&data)
```

## F. Performance

Overall, with ECC disabled, the new codebase maintains roughly the same performance level, with a slight improvement in reading, perhaps due to data width being specified for the log parser.

### Bench with TMR ECC mode

```
Executing bench census90, with tables truncated at row 100000, aggregating 20000 operations
Initializing database in /tmp/bench_census90/
Existing test data removed
Waiting 5s...
Using preferences DBPreferences { log_dir: "/tmp/bench_census90/", ecc_mode: TMR, http_port: Some(20021), tcp_port: None }
took 5882ms to execute 20000 set_unit operations (20000/100000 done), average 0.29ms per item
took 5564ms to execute 20000 set_unit operations (40000/100000 done), average 0.28ms per item
took 5548ms to execute 20000 set_unit operations (60000/100000 done), average 0.28ms per item
took 5515ms to execute 20000 set_unit operations (80000/100000 done), average 0.28ms per item
took 5423ms to execute 20000 set_unit operations (100000/100000 done), average 0.27ms per item
Gained -2.42e-7 ms per item on average
took 6085ms to execute 20000 get_by_key operations (20000/100000 done), average 0.30ms per item
took 6341ms to execute 20000 get_by_key operations (40000/100000 done), average 0.32ms per item
took 6273ms to execute 20000 get_by_key operations (60000/100000 done), average 0.31ms per item
took 7775ms to execute 20000 get_by_key operations (80000/100000 done), average 0.39ms per item
took 5983ms to execute 20000 get_by_key operations (100000/100000 done), average 0.30ms per item
Gained 3.08e-7 ms per item on average
```

### Bench with No ECC

```
andy@carbo: ~/code/immux ecc!
 $ cargo bench --bench census90 -- 100000 20000 --ecc-mode=None                                                                    [16:51:29]
    Finished bench [optimized] target(s) in 0.15s
     Running target/release/deps/census90-9a3b655460b9e0d8

Executing bench census90, with tables truncated at row 100000, aggregating 20000 operations
Initializing database in /tmp/bench_census90/
Existing test data removed
Waiting 5s...
Using preferences DBPreferences { log_dir: "/tmp/bench_census90/", ecc_mode: Identity, http_port: Some(20021), tcp_port: None }
took 5466ms to execute 20000 set_unit operations (20000/100000 done), average 0.27ms per item
took 5371ms to execute 20000 set_unit operations (40000/100000 done), average 0.27ms per item
took 5348ms to execute 20000 set_unit operations (60000/100000 done), average 0.27ms per item
took 5334ms to execute 20000 set_unit operations (80000/100000 done), average 0.27ms per item
took 5414ms to execute 20000 set_unit operations (100000/100000 done), average 0.27ms per item
Gained -3.53e-8 ms per item on average
took 4240ms to execute 20000 get_by_key operations (20000/100000 done), average 0.21ms per item
took 4215ms to execute 20000 get_by_key operations (40000/100000 done), average 0.21ms per item
took 4217ms to execute 20000 get_by_key operations (60000/100000 done), average 0.21ms per item
took 4245ms to execute 20000 get_by_key operations (80000/100000 done), average 0.21ms per item
took 4310ms to execute 20000 get_by_key operations (100000/100000 done), average 0.22ms per item
Gained 4.25e-8 ms per item on average
```

### Bench on Master

```
andy@carbo: ~/code/immux master!
 $ cargo bench --bench census90 -- 100000 20000                                                                                    
    Finished bench [optimized] target(s) in 0.27s
     Running target/release/deps/census90-9a3b655460b9e0d8

Executing bench census90, with tables truncated at row 100000, aggregating 20000 operations
Waiting 5s...
Initializing database in /tmp/bench_census90/
Existing test data removed
took 5368ms to execute 20000 set_unit operations (20000/100000 done), average 0.27ms per item
took 5670ms to execute 20000 set_unit operations (40000/100000 done), average 0.28ms per item
took 5822ms to execute 20000 set_unit operations (60000/100000 done), average 0.29ms per item
took 5476ms to execute 20000 set_unit operations (80000/100000 done), average 0.27ms per item
took 5376ms to execute 20000 set_unit operations (100000/100000 done), average 0.27ms per item
Gained -4.45e-8 ms per item on average
took 4995ms to execute 20000 get_by_key operations (20000/100000 done), average 0.25ms per item
took 4989ms to execute 20000 get_by_key operations (40000/100000 done), average 0.25ms per item
took 4459ms to execute 20000 get_by_key operations (60000/100000 done), average 0.22ms per item
took 4434ms to execute 20000 get_by_key operations (80000/100000 done), average 0.22ms per item
took 4426ms to execute 20000 get_by_key operations (100000/100000 done), average 0.22ms per item
Gained -4.23e-7 ms per item on average
```