### PR TITLE
Import client trait so that methods can be referenced

### DIFF
--- a/benches/anzsic06.rs
+++ b/benches/anzsic06.rs
@@ -5,6 +5,7 @@ use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys::storage::executor::unit_content::UnitContent;
 use immuxsys::storage::executor::unit_key::UnitKey;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
+use immuxsys_client::ImmuxDBClient;
 use immuxsys_dev_utils::data_models::business::Business;
 use immuxsys_dev_utils::dev_utils::{
     csv_to_json_table, e2e_verify_correctness, launch_test_db_servers, measure_iteration,

--- a/benches/berka99.rs
+++ b/benches/berka99.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use immuxsys::constants as Constants;
 use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
+use immuxsys_client::ImmuxDBClient;
 use immuxsys_dev_utils::data_models::berka99::{
     Account, Card, Client, Disp, District, Loan, Order, Trans,
 };

--- a/benches/census90.rs
+++ b/benches/census90.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use immuxsys::constants as Constants;
 use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
+use immuxsys_client::ImmuxDBClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
     csv_to_json_table, e2e_verify_correctness, launch_test_db_servers, measure_iteration,

--- a/benches/covid.rs
+++ b/benches/covid.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use immuxsys::constants as Constants;
 use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
+use immuxsys_client::ImmuxDBClient;
 use immuxsys_dev_utils::data_models::covid::Covid;
 use immuxsys_dev_utils::dev_utils::{
     csv_to_json_table, e2e_verify_correctness, launch_test_db_servers, measure_iteration,

--- a/benches/inspect_all.rs
+++ b/benches/inspect_all.rs
@@ -3,6 +3,7 @@ use std::thread;
 use immuxsys::constants as Constants;
 use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
+use immuxsys_client::ImmuxDBClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
     csv_to_json_table_with_size, launch_test_db_servers, measure_single_operation,

--- a/benches/inspect_one.rs
+++ b/benches/inspect_one.rs
@@ -1,6 +1,7 @@
 use immuxsys::constants as Constants;
 use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
+use immuxsys_client::ImmuxDBClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
     csv_to_json_table, launch_test_db_servers, measure_iteration, read_usize_from_arguments,

--- a/benches/launch_db.rs
+++ b/benches/launch_db.rs
@@ -5,6 +5,7 @@ use immuxsys::storage::executor::executor::Executor;
 use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys::storage::preferences::DBPreferences;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
+use immuxsys_client::ImmuxDBClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
     csv_to_json_table_with_size, launch_test_db_servers, measure_single_operation,

--- a/benches/remove_all.rs
+++ b/benches/remove_all.rs
@@ -3,6 +3,7 @@ use std::thread;
 use immuxsys::constants as Constants;
 use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
+use immuxsys_client::ImmuxDBClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
     csv_to_json_table_with_size, launch_test_db_servers, measure_single_operation,

--- a/benches/remove_single_unit.rs
+++ b/benches/remove_single_unit.rs
@@ -2,6 +2,7 @@ use immuxsys::constants as Constants;
 use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys::storage::executor::unit_content::UnitContent;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
+use immuxsys_client::ImmuxDBClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
     csv_to_json_table, e2e_verify_correctness, launch_test_db_servers, measure_iteration,

--- a/benches/revert_all.rs
+++ b/benches/revert_all.rs
@@ -5,6 +5,7 @@ use immuxsys::storage::chain_height::ChainHeight;
 use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys::storage::executor::unit_content::UnitContent;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
+use immuxsys_client::ImmuxDBClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
     csv_to_json_table, launch_test_db_servers, measure_single_operation, read_usize_from_arguments,

--- a/benches/revert_single_unit.rs
+++ b/benches/revert_single_unit.rs
@@ -5,6 +5,7 @@ use immuxsys::storage::chain_height::ChainHeight;
 use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys::storage::executor::unit_content::UnitContent;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
+use immuxsys_client::ImmuxDBClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
     csv_to_json_table, launch_test_db_servers, measure_iteration, read_usize_from_arguments,

--- a/benches/transactional_set.rs
+++ b/benches/transactional_set.rs
@@ -2,6 +2,7 @@ use immuxsys::constants as Constants;
 use immuxsys::storage::executor::grouping_label::GroupingLabel;
 use immuxsys::storage::transaction_manager::TransactionId;
 use immuxsys_client::http_client::ImmuxDBHttpClient;
+use immuxsys_client::ImmuxDBClient;
 use immuxsys_dev_utils::data_models::census90::CensusEntry;
 use immuxsys_dev_utils::dev_utils::{
     csv_to_json_table, e2e_verify_correctness, launch_test_db_servers, measure_iteration,


### PR DESCRIPTION
After Rust 1.47, `cargo bench` would fail because `ImmuxDBClient` trait wasn't imported and a method cannot be referenced. This PR fixes that.