### PR TITLE
Read log directory from environment and set default to home

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -47,7 +47,8 @@ pub const MISSING_FILTER_MESSAGE: &str = "FILTER argument missing";
 
 pub const TEMP_LOG_FILE_DIR: &str = "/tmp";
 pub const MAIN_LOG_FILENAME: &str = "instruction_log.imm";
-pub const MAIN_LOG_DEFAULT_DIR_UNIX: &str = "/var/immux";
+pub const MAIN_LOG_FALLBACK_DIR_UNIX: &str = "/var/immux_log";
+pub const MAIN_LOG_FALLBACK_DIR_WINDOWS: &str = "C:\\immux_log";
 
 pub const MAX_KEY_LENGTH: usize = 8 * 1024;
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -49,6 +49,8 @@ pub const TEMP_LOG_FILE_DIR: &str = "/tmp";
 pub const MAIN_LOG_FILENAME: &str = "instruction_log.imm";
 pub const MAIN_LOG_FALLBACK_DIR_UNIX: &str = "/var/immux_log";
 pub const MAIN_LOG_FALLBACK_DIR_WINDOWS: &str = "C:\\immux_log";
+pub const MAIN_LOG_DIR_ENV: &str = "IMMUX_LOG";
+pub const MAIN_LOG_DIR_HOME_SUBDIR: &str = "immux_log";
 
 pub const MAX_KEY_LENGTH: usize = 8 * 1024;
 

--- a/src/storage/preferences.rs
+++ b/src/storage/preferences.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::path::PathBuf;
 
 use crate::constants as Constants;
@@ -65,10 +66,35 @@ impl DBPreferences {
     }
 }
 
+fn get_home() -> Option<String> {
+    return if let Ok(home) = env::var("HOME") {
+        Some(home)
+    } else if let Ok(home) = env::var("FOLDERID_Profile") {
+        Some(home)
+    } else {
+        None
+    };
+}
+
+fn get_log_dir() -> PathBuf {
+    return if let Ok(dir) = env::var("IMMUX_LOG") {
+        PathBuf::from(dir)
+    } else {
+        let home = get_home();
+        if let Some(home) = home {
+            PathBuf::from(home).join("immux_log")
+        } else if env::consts::OS == "windows" {
+            PathBuf::from(Constants::MAIN_LOG_FALLBACK_DIR_WINDOWS)
+        } else {
+            PathBuf::from(Constants::MAIN_LOG_FALLBACK_DIR_UNIX)
+        }
+    };
+}
+
 impl Default for DBPreferences {
     fn default() -> Self {
         return Self {
-            log_dir: PathBuf::from(Constants::MAIN_LOG_DEFAULT_DIR_UNIX),
+            log_dir: get_log_dir(),
             ecc_mode: ECCMode::Identity,
             http_port: Some(Constants::HTTP_SERVER_DEFAULT_PORT),
             tcp_port: Some(Constants::TCP_SERVER_DEFAULT_PORT),

--- a/src/storage/preferences.rs
+++ b/src/storage/preferences.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 use crate::constants as Constants;
+use crate::constants::{MAIN_LOG_DIR_ENV, MAIN_LOG_DIR_HOME_SUBDIR};
 use crate::storage::ecc::ECCMode;
 
 const CLI_ARG_DATA_DIR: &str = "--data-dir=";
@@ -69,7 +70,7 @@ impl DBPreferences {
 fn get_home() -> Option<String> {
     return if let Ok(home) = env::var("HOME") {
         Some(home)
-    } else if let Ok(home) = env::var("FOLDERID_Profile") {
+    } else if let Ok(home) = env::var("USERPROFILE") {
         Some(home)
     } else {
         None
@@ -77,12 +78,12 @@ fn get_home() -> Option<String> {
 }
 
 fn get_log_dir() -> PathBuf {
-    return if let Ok(dir) = env::var("IMMUX_LOG") {
+    return if let Ok(dir) = env::var(MAIN_LOG_DIR_ENV) {
         PathBuf::from(dir)
     } else {
         let home = get_home();
         if let Some(home) = home {
-            PathBuf::from(home).join("immux_log")
+            PathBuf::from(home).join(MAIN_LOG_DIR_HOME_SUBDIR)
         } else if env::consts::OS == "windows" {
             PathBuf::from(Constants::MAIN_LOG_FALLBACK_DIR_WINDOWS)
         } else {


### PR DESCRIPTION
Previously, the default log directory of Immux DB is `/var/immux/`, it has two problems:
1. It is most likely not writable by a non-root user
2. It is not usable under Windows.

This PR improves log directory logic:
1. DB will first read `$IMMUX_LOG_DIR` from envrionment, and if set, it is used as the log directory,
2. If step 1 fails, DB looks for user's home directory, and if that is available, it uses `$HOME/immux_log`,
3. If step 2 fails, DB uses the fallback directory, which is `/var/immux_log` for Unix and `C:\immux_log` for Windows.